### PR TITLE
feat: add SVG favicon with DF initials

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0b0b0f" rx="3"/>
+  <text
+    x="16" y="24"
+    text-anchor="middle"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="20"
+    font-style="italic"
+    font-weight="400"
+    fill="#c9a96e"
+    letter-spacing="-1"
+  >DF</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300;0,400;1,300;1,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Adds `favicon.svg` — dark background (`#0b0b0f`), gold italic "DF" in serif font (`#c9a96e`), matching the site's color palette
- Wires it up in `index.html` via `<link rel="icon" type="image/svg+xml">`

## Test plan
- [ ] Open the site and check the browser tab for the favicon
- [ ] Verify it looks correct at small sizes (16×16, 32×32)