### PR TITLE
feat: add X social link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Stack
+
+Plain HTML + CSS + JS. No build step, no dependencies, no package manager. Deployed via GitHub Pages to `damianfanaro.com` (CNAME).
+
+## Running locally
+
+Any static file server works:
+
+```bash
+npx serve .
+# or
+python3 -m http.server
+```
+
+## Architecture
+
+Single-page layout with three files:
+
+- `index.html` — structure and content (bio text, social links with inline SVG icons)
+- `styles.css` — all styling; uses CSS custom properties, `clamp()` for fluid sizing, and CSS animations (`rise` keyframe)
+- `script.js` — two runtime values only: copyright year and years-of-experience calculated from a hardcoded career start date (May 2012)
+
+`favicon.svg` is an SVG with DF initials. `avatar.jpg` is the profile photo. The `archive/` folder holds unused legacy images.
+
+## Design constraints
+
+- Fonts: Cormorant (headings, platform names) + IBM Plex Mono (body, UI)
+- Color palette is fixed via CSS variables in `:root` — dark background `#0b0b0f`, warm foreground `#ede8e0`, gold accent `#c9a96e`
+- Site is English-only; no i18n
+- No contact form, no blog, no nav — intentionally minimal

--- a/index.html
+++ b/index.html
@@ -60,6 +60,17 @@
           <span class="desc">Writing</span>
           <span class="arrow" aria-hidden="true">→</span>
         </a>
+        <a href="https://x.com/damianfanaro" target="_blank" rel="noopener noreferrer" class="link-row">
+          <span class="index">04</span>
+          <span class="platform-group">
+            <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            </svg>
+            <span class="platform">X</span>
+          </span>
+          <span class="desc">Thoughts</span>
+          <span class="arrow" aria-hidden="true">→</span>
+        </a>
       </nav>
 
       <footer>


### PR DESCRIPTION
## Summary
- Adds X ([@damianfanaro](https://x.com/damianfanaro)) as item 04 in the social links nav
- Adds CLAUDE.md with codebase guidance for future Claude Code sessions

## Test plan
- [ ] Visit the site and confirm X link appears below Substack
- [ ] Click the link and verify it opens https://x.com/damianfanaro in a new tab
- [ ] Check hover animation (accent underline sweep, arrow shift) matches other links

🤖 Generated with [Claude Code](https://claude.com/claude-code)