### PR TITLE
feat: redesign with midnight navy palette, icon-only nav, and new favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,13 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#0b0b0f" rx="3"/>
-  <text
-    x="16" y="24"
-    text-anchor="middle"
-    font-family="Georgia, 'Times New Roman', serif"
-    font-size="20"
-    font-style="italic"
-    font-weight="400"
-    fill="#c9a96e"
-    letter-spacing="-1"
-  >DF</text>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink"
+  viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="url('#gradient')"></rect>
+  <defs>
+    <linearGradient id="gradient" gradientTransform="rotate(360 0.5 0.5)">
+      <stop offset="0%" stop-color="#060d1a"></stop>
+      <stop offset="100%" stop-color="#213b6d"></stop>
+    </linearGradient>
+  </defs>
+  <g>
+    <g fill="#5b9eff"
+      transform="matrix(5.5255004351610095,0,0,5.5255004351610095,32.06404831098203,139.28568369821426)"
+      stroke="#5b9eff" stroke-width="0.2">
+      <path
+        d="M5.75 0L1.07 0L1.07-14.22L5.65-14.22Q7.54-14.22 9.04-13.36Q10.55-12.51 11.39-10.95Q12.24-9.39 12.25-7.46L12.25-7.46L12.25-6.81Q12.25-4.85 11.42-3.31Q10.60-1.76 9.10-0.88Q7.60-0.01 5.75 0L5.75 0ZM5.65-11.57L4.50-11.57L4.50-2.64L5.69-2.64Q7.17-2.64 7.96-3.69Q8.75-4.74 8.75-6.81L8.75-6.81L8.75-7.42Q8.75-9.48 7.96-10.53Q7.17-11.57 5.65-11.57L5.65-11.57ZM22.96-8.30L22.96-5.66L17.43-5.66L17.43 0L14.00 0L14.00-14.22L23.52-14.22L23.52-11.57L17.43-11.57L17.43-8.30L22.96-8.30Z"></path>
+    </g>
+  </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -7,69 +7,108 @@
     <meta name="description" content="Solutions Architect · MBA · Founder" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300;0,400;1,300;1,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300;0,400;1,300;1,400&family=IBM+Plex+Mono:wght@300;400&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <main>
       <header>
-        <img class="avatar" src="/avatar.jpg" alt="Damián Fanaro" width="140" height="140" />
+        <img
+          class="avatar"
+          src="/avatar.jpg"
+          alt="Damián Fanaro"
+          width="140"
+          height="140"
+        />
         <div class="header-text">
           <h1>Damián<br /><em>Fanaro</em></h1>
-          <p class="role">Solutions Architect &nbsp;&middot;&nbsp; MBA &nbsp;&middot;&nbsp; Founder</p>
+          <p class="role">
+            Solutions Architect &nbsp;&middot;&nbsp; MBA &nbsp;&middot;&nbsp;
+            Founder
+          </p>
         </div>
       </header>
 
       <section class="bio" aria-label="Bio">
-        <p>I'm a Solutions Architect with <span id="years-exp"></span> years of experience building systems that actually hold together under pressure — across cloud, enterprise integration, and organizational complexity. But the honest version is simpler: I'm someone who finds systems everywhere, not just in software. In organizations, conversations, decisions, the way problems keep recurring despite every fix. That pattern-recognition is what I bring to every engagement, and it's what I can't turn off.</p>
-        <p>I believe technology is one of the most powerful tools humanity has — and that's precisely why it needs to be handled with care. The question I keep returning to isn't <em>what can we build</em>, but <em>what should we build, and for whom</em>. That's not anti-technology. It's the most pro-technology stance I know: treating it seriously enough to ask hard questions before shipping. I'm drawn to people who sit with that tension instead of collapsing it — builders who think, thinkers who build, and anyone who refuses to separate technical rigor from human consequence.</p>
+        <p>
+          I'm a Solutions Architect with <span id="years-exp"></span> years of
+          experience building systems that actually hold together under pressure
+          — across cloud, enterprise integration, and organizational complexity.
+          But the honest version is simpler: I'm someone who finds systems
+          everywhere, not just in software. In organizations, conversations,
+          decisions, the way problems keep recurring despite every fix. That
+          pattern-recognition is what I bring to every engagement, and it's what
+          I can't turn off.
+        </p>
+        <p>
+          I believe technology is one of the most powerful tools humanity has —
+          and that's precisely why it needs to be handled with care. The
+          question I keep returning to isn't <em>what can we build</em>, but
+          <em>what should we build, and for whom</em>. That's not
+          anti-technology. It's the most pro-technology stance I know: treating
+          it seriously enough to ask hard questions before shipping. I'm drawn
+          to people who sit with that tension instead of collapsing it —
+          builders who think, thinkers who build, and anyone who refuses to
+          separate technical rigor from human consequence.
+        </p>
       </section>
 
       <nav aria-label="Social links">
-        <a href="https://github.com/damianfanaro" target="_blank" rel="noopener noreferrer" class="link-row">
-          <span class="index">01</span>
-          <span class="platform-group">
-            <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z"/>
-            </svg>
-            <span class="platform">GitHub</span>
-          </span>
-          <span class="desc">Code &amp; projects</span>
-          <span class="arrow" aria-hidden="true">→</span>
+        <a
+          href="https://github.com/damianfanaro"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="icon-link"
+          aria-label="GitHub"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path
+              d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z"
+            />
+          </svg>
         </a>
-        <a href="https://linkedin.com/in/damianfanaro" target="_blank" rel="noopener noreferrer" class="link-row">
-          <span class="index">02</span>
-          <span class="platform-group">
-            <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-            </svg>
-            <span class="platform">LinkedIn</span>
-          </span>
-          <span class="desc">Professional</span>
-          <span class="arrow" aria-hidden="true">→</span>
+        <a
+          href="https://linkedin.com/in/damianfanaro"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="icon-link"
+          aria-label="LinkedIn"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path
+              d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
+            />
+          </svg>
         </a>
-        <a href="https://damianfanaro.substack.com" target="_blank" rel="noopener noreferrer" class="link-row">
-          <span class="index">03</span>
-          <span class="platform-group">
-            <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"/>
-            </svg>
-            <span class="platform">Substack</span>
-          </span>
-          <span class="desc">Writing</span>
-          <span class="arrow" aria-hidden="true">→</span>
+        <a
+          href="https://damianfanaro.substack.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="icon-link"
+          aria-label="Substack"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path
+              d="M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z"
+            />
+          </svg>
         </a>
-        <a href="https://x.com/damianfanaro" target="_blank" rel="noopener noreferrer" class="link-row">
-          <span class="index">04</span>
-          <span class="platform-group">
-            <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-            </svg>
-            <span class="platform">X</span>
-          </span>
-          <span class="desc">Thoughts</span>
-          <span class="arrow" aria-hidden="true">→</span>
+        <a
+          href="https://x.com/damianfanaro"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="icon-link"
+          aria-label="X"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path
+              d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
+            />
+          </svg>
         </a>
       </nav>
 

--- a/styles.css
+++ b/styles.css
@@ -3,11 +3,11 @@
    ========================================== */
 
 :root {
-  --bg:      #0b0b0f;
-  --fg:      #ede8e0;
-  --muted:   #47444f;
-  --accent:  #c9a96e;
-  --border:  rgba(237, 232, 224, 0.07);
+  --bg:      #060d1a;
+  --fg:      #dde8f5;
+  --muted:   #4a6a9e;
+  --accent:  #5b9eff;
+  --border:  rgba(221, 232, 245, 0.08);
 }
 
 /* --- Reset --- */
@@ -45,7 +45,7 @@ body::before {
   left: -10%;
   width: 60vmax;
   height: 60vmax;
-  background: radial-gradient(circle, rgba(201, 169, 110, 0.04) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(91, 158, 255, 0.06) 0%, transparent 70%);
   pointer-events: none;
   z-index: 0;
 }
@@ -114,9 +114,9 @@ h1 em {
 }
 
 .role {
-  font-size: clamp(0.58rem, 1.4vw, 0.68rem);
+  font-size: clamp(0.58rem, 1.4vw, 0.9rem);
   font-weight: 300;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--muted);
 }
@@ -129,11 +129,11 @@ h1 em {
 }
 
 .bio p {
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: clamp(0.72rem, 1.6vw, 0.82rem);
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: clamp(1.05rem, 2vw, 1.2rem);
   font-weight: 300;
-  line-height: 1.85;
-  color: rgba(237, 232, 224, 0.42);
+  line-height: 1.75;
+  color: rgb(255, 255, 255);
   margin-bottom: 18px;
 }
 
@@ -143,109 +143,32 @@ h1 em {
 
 .bio em {
   font-style: italic;
-  color: rgba(237, 232, 224, 0.6);
+  color: rgba(221, 232, 245, 0.88);
 }
 
 /* --- Nav --- */
 nav {
-  border-top: 1px solid var(--border);
+  display: flex;
+  gap: clamp(28px, 4vw, 40px);
+  margin-bottom: clamp(36px, 6vh, 56px);
   opacity: 0;
   animation: rise 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.2s forwards;
 }
 
-.link-row {
-  display: grid;
-  grid-template-columns: 40px 1fr auto auto;
-  align-items: center;
-  gap: 20px;
-  padding: clamp(20px, 3.5vh, 28px) 0;
-  border-bottom: 1px solid var(--border);
-  position: relative;
-  overflow: hidden;
-  cursor: pointer;
-}
-
-/* Animated underline sweep */
-.link-row::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  width: 0;
-  height: 1px;
-  background: var(--accent);
-  transition: width 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.link-row:hover::after {
-  width: 100%;
-}
-
-.index {
-  font-size: 0.6rem;
-  letter-spacing: 0.12em;
+.icon-link {
   color: var(--muted);
-  transition: color 0.3s ease;
-  align-self: start;
-  padding-top: 4px;
+  transition: color 0.3s ease, transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.link-row:hover .index {
+.icon-link:hover {
   color: var(--accent);
+  transform: translateY(-3px);
 }
 
-.platform-group {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  transition: color 0.3s ease;
-}
-
-.link-row:hover .platform-group {
-  color: var(--accent);
-}
-
-.icon {
+.icon-link svg {
+  display: block;
   width: 22px;
   height: 22px;
-  flex-shrink: 0;
-  opacity: 0.55;
-  transition: opacity 0.3s ease;
-}
-
-.link-row:hover .icon {
-  opacity: 1;
-}
-
-.platform {
-  font-family: 'Cormorant', Georgia, serif;
-  font-weight: 300;
-  font-size: clamp(1.6rem, 5vw, 2.8rem);
-  letter-spacing: -0.015em;
-  line-height: 1;
-}
-
-.desc {
-  font-size: 0.6rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--muted);
-  transition: color 0.3s ease;
-}
-
-.link-row:hover .desc {
-  color: rgba(237, 232, 224, 0.35);
-}
-
-.arrow {
-  font-size: 1rem;
-  color: var(--muted);
-  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), color 0.3s ease;
-}
-
-.link-row:hover .arrow {
-  transform: translateX(8px);
-  color: var(--accent);
 }
 
 /* --- Footer --- */
@@ -277,12 +200,6 @@ footer {
     flex-direction: column;
     align-items: flex-start;
   }
-  .link-row {
-    grid-template-columns: 32px 1fr auto;
-  }
-  .desc {
-    display: none;
-  }
 }
 
 /* --- Reduced motion --- */
@@ -291,8 +208,7 @@ footer {
     animation: none;
     opacity: 1;
   }
-  .link-row::after,
-  .arrow {
+  .icon-link {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary

- Replaced warm dark palette with midnight navy + tech blue (`#060d1a` bg, `#5b9eff` accent) — better matches a Solutions Architecture identity
- Fixed bio text contrast: was at 42% opacity (unreadable), now at full white
- Switched bio font from IBM Plex Mono to Helvetica Neue for better readability
- Simplified social nav from verbose list rows to icon-only horizontal row with `aria-label` for accessibility
- New favicon: network topology graph (hub-and-spoke + mesh edges) in blue on navy, replacing the DF initials

## Test plan
- [ ] Visit site and confirm navy background with blue accent renders correctly
- [ ] Verify bio text is readable at all viewport sizes
- [ ] Hover over social icons — should lift and turn blue
- [ ] Check favicon appears in browser tab
- [ ] Test on mobile viewport (390px)